### PR TITLE
Add template seeder

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from log import setup_logging
 from flask_login import LoginManager, current_user
 from seeder.seed_user import seed_admin_user
 from seeder.seed_cloudflare_account import seed_cloudflare_account
+from seeder.seed_template import seed_template
 
 from util.until import format_datetime
 from models.user import User
@@ -112,4 +113,5 @@ if __name__ == "__main__":
         db.create_all()
         seed_admin_user(app)
         seed_cloudflare_account(app)
+        seed_template(app)
     app.run(host="0.0.0.0", port=4000, debug=True)

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -37,7 +37,7 @@ GenWeb/
 - **routes/** – Các blueprint Flask phân theo chức năng (`auth`, `domain`, `dns`, `cloudflare_account`, `admin`, `home`).
 - **templates/** – Giao diện Jinja2 dùng để render trang HTML.
 - **static/** – Tài nguyên tĩnh (CSS, JS) phục vụ template.
-- **seeder/** – Script khởi tạo dữ liệu mẫu như user admin và Cloudflare account.
+- **seeder/** – Script khởi tạo dữ liệu mẫu như user admin, Cloudflare account và template mặc định.
 - **util/** – Hàm tiện ích, đặc biệt `cloud_flare.py` thao tác API Cloudflare.
 - **Form/** – Định nghĩa các WTForms cho đăng ký, đăng nhập và form cấu hình domain.
 - **Fashion-eCommerce/** – Source code frontend mẫu viết bằng React + TypeScript sử dụng Vite.

--- a/seeder/seed_template.py
+++ b/seeder/seed_template.py
@@ -1,0 +1,23 @@
+# seeder/seed_template.py
+from models.template import Template
+from database_init import db
+
+
+def seed_template(app):
+    """Seed a sample frontend template."""
+    with app.app_context():
+        name = "Default Template"
+        description = "Sample template for company website"
+        sample_url = "smartrent.id.vn"
+
+        if not Template.query.filter_by(name=name).first():
+            template = Template(
+                name=name,
+                description=description,
+                sample_url=sample_url,
+            )
+            db.session.add(template)
+            db.session.commit()
+            print(f"✅ Đã tạo Template: {name}")
+        else:
+            print("⚠️ Template đã tồn tại, bỏ qua.")


### PR DESCRIPTION
## Summary
- seed a default template
- wire template seeder into app initialization
- document template seeder in project structure docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886f019e12083258e58e99b364f768c