### PR TITLE
Add seeding for UserFE and orders

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,8 @@ from seeder.seed_cloudflare_account import seed_cloudflare_account
 from seeder.seed_template import seed_template
 from seeder.seed_company import seed_companies
 from seeder.seed_product import seed_product
+from seeder.seed_user_fe import seed_user_fe
+from seeder.seed_order import seed_orders
 
 from util.until import format_datetime
 from models.user import User
@@ -126,4 +128,6 @@ if __name__ == "__main__":
         seed_template(app)
         seed_companies(app)
         seed_product(app)
+        seed_user_fe(app)
+        seed_orders(app)
     app.run(host="0.0.0.0", port=4000, debug=True)

--- a/seeder/data/order.json
+++ b/seeder/data/order.json
@@ -1,0 +1,404 @@
+[
+  {
+    "data": {
+      "emailAddress": "bc22@gmail.com",
+      "firstName": "Bojan",
+      "lastName": "Cesnak",
+      "company": "BC",
+      "address": "B2",
+      "apartment": "123",
+      "city": "Belgrade",
+      "country": "United States",
+      "region": "Serbia",
+      "postalCode": "11080",
+      "phone": "06123123132",
+      "paymentType": "on",
+      "cardNumber": "12313212",
+      "nameOnCard": "123123",
+      "expirationDate": "123123",
+      "cvc": "12312"
+    },
+    "products": [
+      {
+        "id": "2xsblack",
+        "image": "product image 2.jpg",
+        "title": "Luxury Black Clothing",
+        "category": "luxury-collection",
+        "price": 1050,
+        "quantity": 3,
+        "size": "xs",
+        "color": "black",
+        "popularity": 4,
+        "stock": 20
+      }
+    ],
+    "subtotal": 3150,
+    "user": {
+      "email": "bc22@gmail.com",
+      "id": 2
+    },
+    "id": 1
+  },
+  {
+    "data": {
+      "emailAddress": "bc22@gmail.com",
+      "firstName": "Bojan",
+      "lastName": "Cesnak",
+      "company": "asd",
+      "address": "asd",
+      "apartment": "123",
+      "city": "Belgrade",
+      "country": "United States",
+      "region": "123",
+      "postalCode": "123",
+      "phone": "123",
+      "paymentType": "on",
+      "cardNumber": "123",
+      "nameOnCard": "123",
+      "expirationDate": "123",
+      "cvc": "123"
+    },
+    "products": [
+      {
+        "id": "2xlblack",
+        "image": "product image 2.jpg",
+        "title": "Luxury Black Clothing",
+        "category": "luxury-collection",
+        "price": 1050,
+        "quantity": 3,
+        "size": "xl",
+        "color": "black",
+        "popularity": 4,
+        "stock": 20
+      }
+    ],
+    "subtotal": 3150,
+    "user": {
+      "email": "bc22@gmail.com",
+      "id": 2
+    },
+    "orderStatus": "Processing",
+    "orderDate": "2024-08-31T06:54:38.482Z",
+    "id": 2
+  },
+  {
+    "data": {
+      "emailAddress": "a@gmail.com",
+      "firstName": "Aca",
+      "lastName": "Kuzma",
+      "company": "Bojan Cesnak",
+      "address": "Marka Markovic 22",
+      "apartment": "123",
+      "city": "Belgrade",
+      "country": "United States",
+      "region": "Serbia",
+      "postalCode": "11080",
+      "phone": "06123123132",
+      "paymentType": "on",
+      "cardNumber": "123",
+      "nameOnCard": "123",
+      "expirationDate": "123",
+      "cvc": "123"
+    },
+    "products": [
+      {
+        "id": "1xlblack",
+        "image": "product image 1.jpg",
+        "title": "Luxury Dress",
+        "category": "special-edition",
+        "price": 3500,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 5,
+        "stock": 10
+      },
+      {
+        "id": "4xlblack",
+        "image": "product image 4.jpg",
+        "title": "Special Brown Dress",
+        "category": "unique-collection",
+        "price": 2500,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 2,
+        "stock": 15
+      }
+    ],
+    "subtotal": 6000,
+    "user": {
+      "email": "aleksandarkuzmanovic021@gmail.com",
+      "id": 1
+    },
+    "orderStatus": "Processing",
+    "orderDate": "2024-08-31T07:01:32.959Z",
+    "id": 3
+  },
+  {
+    "data": {
+      "emailAddress": "a@gmail.com",
+      "firstName": "Aca",
+      "lastName": "Kuzma",
+      "company": "123",
+      "address": "123",
+      "apartment": "123",
+      "city": "Belgrade",
+      "country": "United States",
+      "region": "Serbia",
+      "postalCode": "11080",
+      "phone": "123",
+      "paymentType": "on",
+      "cardNumber": "123",
+      "nameOnCard": "123",
+      "expirationDate": "123",
+      "cvc": "123"
+    },
+    "products": [
+      {
+        "id": "1xlblack",
+        "image": "product image 1.jpg",
+        "title": "Luxury Dress",
+        "category": "special-edition",
+        "price": 3500,
+        "quantity": 2,
+        "size": "xl",
+        "color": "black",
+        "popularity": 5,
+        "stock": 10
+      }
+    ],
+    "subtotal": 7000,
+    "user": {
+      "email": "aleksandarkuzmanovic021@gmail.com",
+      "id": 1
+    },
+    "orderStatus": "Processing",
+    "orderDate": "2024-08-31T07:07:37.188Z",
+    "id": 4
+  },
+  {
+    "data": {
+      "emailAddress": "bc22@gmail.com",
+      "firstName": "Bojan",
+      "lastName": "Cesnak",
+      "company": "Bojan Cesnak",
+      "address": "Marka Markovic 22",
+      "apartment": "123",
+      "city": "Belgrade",
+      "country": "United States",
+      "region": "Serbia",
+      "postalCode": "11080",
+      "phone": "06123123132",
+      "paymentType": "on",
+      "cardNumber": "123",
+      "nameOnCard": "123",
+      "expirationDate": "123",
+      "cvc": "123"
+    },
+    "products": [
+      {
+        "id": "6xlblack",
+        "image": "product image 6.jpg",
+        "title": "Super Luxury Dress",
+        "category": "luxury-collection",
+        "price": 8500,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 20,
+        "stock": 20
+      },
+      {
+        "id": "5xlblack",
+        "image": "product image 5.jpg",
+        "title": "Special Luxury Dress",
+        "category": "unique-collection",
+        "price": 5200,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 1,
+        "stock": 0
+      },
+      {
+        "id": "4xlblack",
+        "image": "product image 4.jpg",
+        "title": "Special Brown Dress",
+        "category": "unique-collection",
+        "price": 2500,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 2,
+        "stock": 15
+      },
+      {
+        "id": "3xlblack",
+        "image": "product image 3.jpg",
+        "title": "Luxury Blue Dress",
+        "category": "summer-edition",
+        "price": 5000,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 3,
+        "stock": 5
+      },
+      {
+        "id": "2xlblack",
+        "image": "product image 2.jpg",
+        "title": "Luxury Black Clothing",
+        "category": "luxury-collection",
+        "price": 1050,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 4,
+        "stock": 20
+      },
+      {
+        "id": "1xlblack",
+        "image": "product image 1.jpg",
+        "title": "Luxury Dress",
+        "category": "special-edition",
+        "price": 3500,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 5,
+        "stock": 10
+      }
+    ],
+    "subtotal": 25750,
+    "user": {
+      "email": "bc22@gmail.com",
+      "id": 2
+    },
+    "orderStatus": "Processing",
+    "orderDate": "2024-08-31T07:12:42.805Z",
+    "id": 5
+  },
+  {
+    "data": {
+      "emailAddress": "a@gmail.com",
+      "firstName": "Aca",
+      "lastName": "Cesnak",
+      "company": "Bojan Cesnak",
+      "address": "Marka Markovic 22",
+      "apartment": "123",
+      "city": "Belgrade",
+      "country": "United States",
+      "region": "Serbia",
+      "postalCode": "11080",
+      "phone": "06123123132",
+      "paymentType": "on",
+      "cardNumber": "123",
+      "nameOnCard": "321",
+      "expirationDate": "123",
+      "cvc": "321"
+    },
+    "products": [
+      {
+        "id": "2xlblack",
+        "image": "product image 2.jpg",
+        "title": "Luxury Black Clothing",
+        "category": "luxury-collection",
+        "price": 1050,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 4,
+        "stock": 20
+      }
+    ],
+    "subtotal": 1050,
+    "orderStatus": "Processing",
+    "orderDate": "8/31/2024",
+    "id": 6
+  },
+  {
+    "data": {
+      "emailAddress": "a@gmail.com",
+      "firstName": "Aca",
+      "lastName": "Cesnak",
+      "company": "Bojan Cesnak",
+      "address": "Marka Markovic 22",
+      "apartment": "123",
+      "city": "asd",
+      "country": "United States",
+      "region": "Serbia",
+      "postalCode": "11080",
+      "phone": "06123123132",
+      "paymentType": "on",
+      "cardNumber": "123",
+      "nameOnCard": "321",
+      "expirationDate": "123",
+      "cvc": "321"
+    },
+    "products": [
+      {
+        "id": "2xlblack",
+        "image": "product image 2.jpg",
+        "title": "Luxury Black Clothing",
+        "category": "luxury-collection",
+        "price": 1050,
+        "quantity": 1,
+        "size": "xl",
+        "color": "black",
+        "popularity": 4,
+        "stock": 20
+      }
+    ],
+    "subtotal": 1050,
+    "user": {
+      "email": "a@gmail.com",
+      "id": 3
+    },
+    "orderStatus": "Processing",
+    "orderDate": "2024-08-31T07:47:13.076Z",
+    "id": 7
+  },
+  {
+    "data": {
+      "emailAddress": "lebronjames@gmail.com",
+      "firstName": "Lebron",
+      "lastName": "James",
+      "company": "NBA",
+      "address": "NBA Street",
+      "apartment": "212",
+      "city": "Cleveland",
+      "country": "United States",
+      "region": "USA",
+      "postalCode": "1123012",
+      "phone": "123123",
+      "paymentType": "on",
+      "cardNumber": "123",
+      "nameOnCard": "123",
+      "expirationDate": "123",
+      "cvc": "123"
+    },
+    "products": [
+      {
+        "id": "2smblue",
+        "image": "product image 2.jpg",
+        "title": "Luxury Black Clothing",
+        "category": "luxury-collection",
+        "price": 1050,
+        "quantity": 3,
+        "size": "sm",
+        "color": "blue",
+        "popularity": 4,
+        "stock": 20
+      }
+    ],
+    "subtotal": 3150,
+    "user": {
+      "email": "lebronjames@gmail.com",
+      "id": 4
+    },
+    "orderStatus": "Processing",
+    "orderDate": "2024-08-31T09:54:07.549Z",
+    "id": 8
+  }
+]

--- a/seeder/data/user_fe.json
+++ b/seeder/data/user_fe.json
@@ -1,0 +1,33 @@
+[
+  {
+    "name": "Aleksandar",
+    "lastname": "Kuzmanovic",
+    "email": "aleksandarkuzmanovic021@gmail.com",
+    "password": "1233214321",
+    "id": 1
+  },
+  {
+    "name": "Bojan",
+    "lastname": "Cesnak",
+    "email": "bc22@gmail.com",
+    "password": "123321",
+    "confirmPassword": "123321",
+    "id": 2
+  },
+  {
+    "name": "A",
+    "lastname": "A",
+    "email": "a@gmail.com",
+    "password": "123321",
+    "confirmPassword": "123321",
+    "id": 3
+  },
+  {
+    "name": "Lebron",
+    "lastname": "James",
+    "email": "lebronjames@gmail.com",
+    "password": "1233214321",
+    "confirmPassword": "1233214321",
+    "id": 4
+  }
+]

--- a/seeder/seed_order.py
+++ b/seeder/seed_order.py
@@ -1,0 +1,74 @@
+import json
+import os
+from datetime import datetime
+from models.order import Order
+from models.order_item import OrderItem
+from models.user_fe import UserFE
+from models.product import Product
+from database_init import db
+
+
+def _parse_date(date_str):
+    """Chuyển chuỗi thời gian thành datetime."""
+    if not date_str:
+        return None
+    try:
+        if 'T' in date_str:
+            if date_str.endswith('Z'):
+                date_str = date_str[:-1]
+            return datetime.fromisoformat(date_str)
+        return datetime.strptime(date_str, "%m/%d/%Y")
+    except Exception:
+        return None
+
+
+def seed_orders(app):
+    """Seed orders và order items từ ./data/order.json vào database."""
+    data_file = os.path.join(os.path.dirname(__file__), "./data/order.json")
+    data_file = os.path.abspath(data_file)
+
+    with open(data_file, "r", encoding="utf-8") as f:
+        orders = json.load(f)
+
+    with app.app_context():
+        added_count = 0
+        for od in orders:
+            user = UserFE.query.filter_by(email=od.get("user", {}).get("email")).first()
+            if not user:
+                continue
+            order_date = _parse_date(od.get("orderDate"))
+            exists = Order.query.filter_by(user_fe_id=user.id, order_date=order_date).first()
+            if exists:
+                continue
+            order = Order(
+                user_fe_id=user.id,
+                order_status=od.get("orderStatus", "Processing"),
+                order_date=order_date,
+                subtotal=od.get("subtotal", 0),
+                shipping_address=od.get("data", {}).get("address"),
+                phone=od.get("data", {}).get("phone"),
+                payment_type=od.get("data", {}).get("paymentType"),
+            )
+            db.session.add(order)
+            db.session.flush()
+            for item in od.get("products", []):
+                prod = Product.query.filter_by(title=item.get("title")).first()
+                if not prod:
+                    continue
+                order_item = OrderItem(
+                    order_id=order.id,
+                    product_id=prod.id,
+                    quantity=item.get("quantity", 1),
+                    price=item.get("price", 0),
+                    size=item.get("size"),
+                    color=item.get("color"),
+                    popularity=item.get("popularity"),
+                    stock=item.get("stock"),
+                )
+                db.session.add(order_item)
+            added_count += 1
+        if added_count > 0:
+            db.session.commit()
+            print(f"✅ Đã thêm {added_count} đơn hàng mới.")
+        else:
+            print("⚠️ Không có đơn hàng mới để thêm (đã tồn tại hết).")

--- a/seeder/seed_user_fe.py
+++ b/seeder/seed_user_fe.py
@@ -1,0 +1,33 @@
+import json
+from models.user_fe import UserFE
+from database_init import db
+import os
+
+
+def seed_user_fe(app):
+    """Seed user FE data from ./data/user_fe.json into database."""
+    data_file = os.path.join(os.path.dirname(__file__), "./data/user_fe.json")
+    data_file = os.path.abspath(data_file)
+
+    with open(data_file, "r", encoding="utf-8") as f:
+        users = json.load(f)
+
+    with app.app_context():
+        added_count = 0
+        for u in users:
+            if not UserFE.query.filter_by(email=u["email"]).first():
+                user = UserFE(
+                    name=u["name"],
+                    lastname=u.get("lastname"),
+                    email=u["email"],
+                    password=u["password"],
+                    phone=u.get("phone"),
+                    address=u.get("address"),
+                )
+                db.session.add(user)
+                added_count += 1
+        if added_count > 0:
+            db.session.commit()
+            print(f"✅ Đã thêm {added_count} user FE mới.")
+        else:
+            print("⚠️ Không có user FE mới để thêm (đã tồn tại hết).")


### PR DESCRIPTION
## Summary
- add JSON seed data for UserFE and Order
- create seeder scripts `seed_user_fe.py` and `seed_order.py`
- update `app.py` to run new seeders on startup

## Testing
- `python3 -m py_compile seeder/seed_user_fe.py seeder/seed_order.py`

------
https://chatgpt.com/codex/tasks/task_e_68884f7dfd748325991e730689edab9a