### PR TITLE
Fix responsive width of product cards

### DIFF
--- a/template_fe/template_default/src/components/ProductItem.tsx
+++ b/template_fe/template_default/src/components/ProductItem.tsx
@@ -19,12 +19,12 @@ const ProductItem = ({
   stock: number;        // <--- thêm
 }) => {
   return (
-    <div className="w-full max-w-[400px] flex flex-col gap-2 justify-center mx-auto">
+    <div className="w-full md:max-w-[400px] flex flex-col gap-2 justify-center mx-auto">
       <Link
         to={`/product/${id}`}
         className="w-full h-[300px] max-md:h-[200px] overflow-hidden"
       >
-        <img src={`/src/assets/${image}`} alt={title} />
+        <img src={`/src/assets/${image}`} alt={title} className="w-full h-full object-cover" />
       </Link>
       <Link
         to={`/product/${id}`}


### PR DESCRIPTION
## Summary
- ensure product cards fill the available width on small screens
- prevent images from overflowing their containers

## Testing
- `npm install` *(fails: internet restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68886053c0408325bb5fbb1606e03159