### PR TITLE
Fix responsive layout for categories

### DIFF
--- a/template_fe/template_default/src/components/CategoriesSection.tsx
+++ b/template_fe/template_default/src/components/CategoriesSection.tsx
@@ -6,7 +6,7 @@ const CategoriesSection = () => {
       <h2 className="text-black text-5xl font-normal tracking-[1.56px] max-sm:text-4xl mb-12">
         Our Categories
       </h2>
-      <div className="flex justify-between flex-wrap gap-y-10">
+      <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
         <CategoryItem
           categoryTitle="Special Edition"
           image="luxury category 1.png"

--- a/template_fe/template_default/src/components/CategoryItem.tsx
+++ b/template_fe/template_default/src/components/CategoryItem.tsx
@@ -1,13 +1,13 @@
 import { Link } from "react-router-dom";
 
-const CategoryItem = ({ categoryTitle, image, link } : { categoryTitle: string; image: string; link: string; }) => {
+const CategoryItem = ({ categoryTitle, image, link }: { categoryTitle: string; image: string; link: string }) => {
   return (
-    <div className="w-[600px] relative max-[1250px]:w-[400px] max-[1250px]:h-[400px] max-sm:w-[300px] max-sm:h-[300px]">
+    <div className="relative w-full aspect-square">
       <Link to={`/shop/${link}`}>
-      <img src={`/src/assets/${image}`} className="h-full w-full" />
-      <div className="bg-secondaryBrown text-white absolute bottom-0 w-full h-16 flex justify-center items-center max-sm:h-12">
-        <h3 className="text-2xl max-sm:text-xl">{ categoryTitle }</h3>
-      </div>
+        <img src={`/src/assets/${image}`} className="h-full w-full object-cover" />
+        <div className="bg-secondaryBrown text-white absolute bottom-0 w-full h-16 flex justify-center items-center max-sm:h-12">
+          <h3 className="text-2xl max-sm:text-xl">{categoryTitle}</h3>
+        </div>
       </Link>
     </div>
   );


### PR DESCRIPTION
## Summary
- improve `CategoryItem` layout to use full width and aspect ratio
- use grid in `CategoriesSection` for better responsiveness

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_6888630e74388325bd4820f75fd643d9