### PR TITLE
Add website management blueprint

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,6 +88,7 @@ def create_app():
     from routes.dns import dns_bp
     from routes.cloudflare_account import cloudflare_bp
     from routes.company import company_bp
+    from routes.website import website_bp
     from routes.api import api_bp
 
     app.register_blueprint(home_bp)
@@ -97,6 +98,7 @@ def create_app():
     app.register_blueprint(dns_bp)
     app.register_blueprint(cloudflare_bp)
     app.register_blueprint(company_bp)
+    app.register_blueprint(website_bp)
     app.register_blueprint(api_bp)
 
     # Kiểm soát truy cập: dùng Flask-Login, không cần kiểm tra "facebook_user_id" nữa

--- a/docs/backend_endpoints.md
+++ b/docs/backend_endpoints.md
@@ -64,6 +64,15 @@ Tất cả các route có tiền tố `/company` và yêu cầu đăng nhập.
 | `/company/edit/<company_id>` | GET, POST | Sửa thông tin công ty |
 | `/company/delete/<company_id>` | POST | Xóa công ty |
 
+## Quản lý Website (`website_bp`)
+Các route có tiền tố `/website` và yêu cầu đăng nhập.
+
+| Đường dẫn | Phương thức | Mô tả |
+| --- | --- | --- |
+| `/website/` | GET | Liệt kê website của người dùng |
+| `/website/add` | GET, POST | Tạo website mới |
+| `/website/delete/<website_id>` | POST | Xóa website |
+
 ## API Frontend (`api_fe_bp`)
 Các route có tiền tố `/api` và không yêu cầu đăng nhập.
 

--- a/routes/website.py
+++ b/routes/website.py
@@ -1,0 +1,79 @@
+from flask import Blueprint, render_template, redirect, url_for, request, flash
+from flask_login import login_required, current_user
+from database_init import db
+from models.website import Website
+from models.company import Company
+from models.dns_record import DNSRecord
+from models.template import Template
+from models.domain import Domain
+
+website_bp = Blueprint("website", __name__, url_prefix="/website")
+
+
+@website_bp.route("/")
+@login_required
+def list_websites():
+    """Hiển thị danh sách website của người dùng hiện tại."""
+    websites = Website.query.filter_by(user_id=current_user.id).all()
+    return render_template("website/list.html", websites=websites)
+
+
+@website_bp.route("/add", methods=["GET", "POST"])
+@login_required
+def add_website():
+    """Tạo website mới cho công ty đã có."""
+    companies = Company.query.filter_by(user_id=current_user.id).all()
+    # Lấy tất cả DNS record thuộc domain của user
+    dns_records = (
+        DNSRecord.query.join(Domain)
+        .filter(Domain.user_id == current_user.id)
+        .all()
+    )
+    templates = Template.query.all()
+
+    if request.method == "POST":
+        company_id = request.form.get("company_id", type=int)
+        dns_record_id = request.form.get("dns_record_id", type=int)
+        template_id = request.form.get("template_id", type=int)
+        static_page_link = request.form.get("static_page_link", "")
+        note = request.form.get("note", "")
+
+        if not company_id or not dns_record_id:
+            flash("Vui lòng chọn công ty và DNS record", "danger")
+            return render_template(
+                "website/add.html",
+                companies=companies,
+                dns_records=dns_records,
+                templates=templates,
+            )
+
+        website = Website(
+            company_id=company_id,
+            dns_record_id=dns_record_id,
+            template_id=template_id,
+            static_page_link=static_page_link,
+            note=note,
+            user_id=current_user.id,
+        )
+        db.session.add(website)
+        db.session.commit()
+        flash("Đã tạo website thành công.", "success")
+        return redirect(url_for("website.list_websites"))
+
+    return render_template(
+        "website/add.html",
+        companies=companies,
+        dns_records=dns_records,
+        templates=templates,
+    )
+
+
+@website_bp.route("/delete/<int:website_id>", methods=["POST"])
+@login_required
+def delete_website(website_id):
+    """Xóa website thuộc quyền sở hữu của người dùng."""
+    website = Website.query.filter_by(id=website_id, user_id=current_user.id).first_or_404()
+    db.session.delete(website)
+    db.session.commit()
+    flash("Đã xóa website.", "success")
+    return redirect(url_for("website.list_websites"))

--- a/templates/website/add.html
+++ b/templates/website/add.html
@@ -1,0 +1,45 @@
+{% extends "base.html" %}
+{% block title %}Thêm Website{% endblock %}
+
+{% block content %}
+<h2>Thêm Website</h2>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Chọn Công ty</label>
+        <select name="company_id" class="form-select" required>
+            <option value="">-- Chọn --</option>
+            {% for c in companies %}
+            <option value="{{ c.id }}">{{ c.name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Chọn DNS Record</label>
+        <select name="dns_record_id" class="form-select" required>
+            <option value="">-- Chọn --</option>
+            {% for d in dns_records %}
+            <option value="{{ d.id }}">{{ d.name }} ({{ d.record_type }})</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Template</label>
+        <select name="template_id" class="form-select">
+            <option value="">-- Không --</option>
+            {% for t in templates %}
+            <option value="{{ t.id }}">{{ t.name }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Static Page Link</label>
+        <input type="text" name="static_page_link" class="form-control">
+    </div>
+    <div class="mb-3">
+        <label class="form-label">Note</label>
+        <textarea name="note" class="form-control"></textarea>
+    </div>
+    <button type="submit" class="btn btn-success">Tạo</button>
+    <a href="{{ url_for('website.list_websites') }}" class="btn btn-secondary">Hủy</a>
+</form>
+{% endblock %}

--- a/templates/website/list.html
+++ b/templates/website/list.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% block title %}Danh sách Website{% endblock %}
+
+{% block content %}
+<h2>Danh sách Website</h2>
+<a href="{{ url_for('website.add_website') }}" class="btn btn-primary mb-3">+ Thêm website</a>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Công ty</th>
+            <th>DNS Record</th>
+            <th>Template</th>
+            <th>Hành động</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for w in websites %}
+        <tr>
+            <td>{{ w.id }}</td>
+            <td>{{ w.company.name if w.company else '' }}</td>
+            <td>{{ w.dns_record.name if w.dns_record else '' }}</td>
+            <td>{{ w.template.name if w.template else 'N/A' }}</td>
+            <td>
+                <form action="{{ url_for('website.delete_website', website_id=w.id) }}" method="post" style="display:inline;" onsubmit="return confirm('Xóa website này?');">
+                    <button type="submit" class="btn btn-sm btn-danger">Xóa</button>
+                </form>
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support basic website CRUD routes
- register new blueprint in `app.py`
- document the new endpoints
- add HTML templates for listing and creating websites

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888826d98248325bce788578526b6b1