### PR TITLE
Add contact page and update frontend footer

### DIFF
--- a/docs/frontend_routes.md
+++ b/docs/frontend_routes.md
@@ -17,5 +17,6 @@ Phần frontend React định nghĩa các route trong `src/App.tsx` sử dụng 
 | `/user-profile` | `UserProfile` | trang hồ sơ người dùng |
 | `/order-history` | `OrderHistory` | loader `orderHistoryLoader` |
 | `/order-history/:id` | `SingleOrderHistory` | loader `singleOrderLoader` |
+| `/contact` | `Contact` | trang liên hệ |
 
 Tất cả các route đều được lồng trong `HomeLayout`, do đó các thành phần giao diện chung (header, footer, ...) được cung cấp bởi layout này.

--- a/template_fe/template_default/src/App.tsx
+++ b/template_fe/template_default/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Login,
   OrderConfirmation,
   OrderHistory,
+  Contact,
   Register,
   Search,
   Shop,
@@ -80,6 +81,10 @@ const router = createBrowserRouter([
         path: "order-history/:id",
         element: <SingleOrderHistory />,
         loader: singleOrderLoader
+      },
+      {
+        path: "contact",
+        element: <Contact />,
       },
     ],
   },

--- a/template_fe/template_default/src/components/Footer.tsx
+++ b/template_fe/template_default/src/components/Footer.tsx
@@ -1,8 +1,30 @@
 import SocialMediaFooter from "./SocialMediaFooter";
 import { HiChevronDown } from "react-icons/hi2";
+import { useEffect, useState } from "react";
+import customFetch from "../axios/custom";
 
+interface CompanyInfo {
+  address: string;
+  hotline: string;
+  email: string;
+  footer_text: string;
+}
 
 const Footer = () => {
+  const [company, setCompany] = useState<CompanyInfo | null>(null);
+
+  useEffect(() => {
+    const loadCompany = async () => {
+      try {
+        const response = await customFetch.get("/company");
+        setCompany(response.data);
+      } catch (error) {
+        console.error("Failed to fetch company info", error);
+      }
+    };
+    loadCompany();
+  }, []);
+
   return (
     <>
       <SocialMediaFooter />
@@ -32,7 +54,14 @@ const Footer = () => {
         <div className="flex flex-col gap-8 my-20">
           <p className="flex justify-center items-center text-2xl gap-2 max-sm:text-xl">Worldwide / English <HiChevronDown /></p>
           <h2 className="text-6xl font-light text-center max-sm:text-5xl">FASHION</h2>
-          <p className="text-base text-center max-sm:text-sm">All rights reserved ©2024</p>
+          <p className="text-base text-center max-sm:text-sm">{company?.footer_text || 'All rights reserved ©2024'}</p>
+          {company && (
+            <div className="text-center text-base flex flex-col gap-1 max-sm:text-sm">
+              <p>{company.address}</p>
+              <p>{company.email}</p>
+              <p>{company.hotline}</p>
+            </div>
+          )}
           <ul className="flex justify-center items-center gap-7 text-base max-sm:text-sm max-[350px]:flex-col max-[350px]:gap-5">
             <li>Cookie Policy</li>
             <li>Privacy Policy</li>

--- a/template_fe/template_default/src/components/SidebarMenu.tsx
+++ b/template_fe/template_default/src/components/SidebarMenu.tsx
@@ -76,6 +76,12 @@ const SidebarMenu = ({
             >
               Search
             </Link>
+            <Link
+              to="/contact"
+              className="py-2 border-y border-secondaryBrown w-full block flex justify-center"
+            >
+              Contact
+            </Link>
             {loginStatus ? (
               <>
                 <button

--- a/template_fe/template_default/src/pages/Contact.tsx
+++ b/template_fe/template_default/src/pages/Contact.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import customFetch from "../axios/custom";
+
+interface Company {
+  name: string;
+  address: string;
+  hotline: string;
+  email: string;
+  google_map_embed: string;
+  description: string;
+  footer_text: string;
+}
+
+const Contact = () => {
+  const [company, setCompany] = useState<Company | null>(null);
+
+  useEffect(() => {
+    const fetchCompany = async () => {
+      try {
+        const response = await customFetch.get("/company");
+        setCompany(response.data);
+      } catch (error) {
+        console.error("Failed to fetch company info", error);
+      }
+    };
+    fetchCompany();
+  }, []);
+
+  if (!company) {
+    return <div className="max-w-screen-2xl mx-auto px-5 mt-24">Loading...</div>;
+  }
+
+  return (
+    <div className="max-w-screen-2xl mx-auto px-5 mt-24 flex flex-col gap-6">
+      <h1 className="text-3xl font-bold">Contact Us</h1>
+      {company.description && <p>{company.description}</p>}
+      <div>
+        <h2 className="text-xl font-semibold">Address</h2>
+        <p>{company.address}</p>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold">Email</h2>
+        <p>{company.email}</p>
+      </div>
+      <div>
+        <h2 className="text-xl font-semibold">Hotline</h2>
+        <p>{company.hotline}</p>
+      </div>
+      {company.google_map_embed && (
+        <div dangerouslySetInnerHTML={{ __html: company.google_map_embed }} />
+      )}
+    </div>
+  );
+};
+
+export default Contact;

--- a/template_fe/template_default/src/pages/index.ts
+++ b/template_fe/template_default/src/pages/index.ts
@@ -11,3 +11,4 @@ export { default as OrderConfirmation } from "./OrderConfirmation";
 export { default as UserProfile } from "./UserProfile";
 export { default as OrderHistory } from "./OrderHistory";
 export { default as SingleOrderHistory } from "./SingleOrderHistory";
+export { default as Contact } from "./Contact";


### PR DESCRIPTION
## Summary
- create new `Contact` page in template_fe
- export `Contact` and wire up new `/contact` route
- show contact link in sidebar navigation
- load company info in footer and display it
- document `/contact` in frontend routes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688918a642e083259d35f5cbc28fa7f8