### PR TITLE
Improve footer spacing and cleanup contact page

### DIFF
--- a/template_fe/template_default/src/pages/Contact.tsx
+++ b/template_fe/template_default/src/pages/Contact.tsx
@@ -37,7 +37,7 @@ const Contact = () => {
   }
 
   return (
-    <div className="max-w-2xl mx-auto px-5 mt-24 flex flex-col gap-8 bg-white shadow-lg rounded-2xl py-10">
+    <div className="max-w-2xl mx-auto px-5 mt-24 flex flex-col gap-8 py-10">
       {/* Logo & Tên công ty */}
       <div className="flex flex-col items-center gap-3">
         {company.logo_url && (
@@ -82,7 +82,7 @@ const Contact = () => {
 
       {/* Google Map */}
       {company.google_map_embed && (
-        <div className="rounded overflow-hidden shadow">
+        <div className="rounded overflow-hidden">
           <div
             className="w-full h-64"
             dangerouslySetInnerHTML={{ __html: company.google_map_embed }}

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,4 +1,4 @@
-<footer class="bg-dark text-light">
+<footer class="bg-dark text-light mt-5 pt-4">
     <div class="container">
         <div class="row g-4 justify-content-between">
             <!-- Company Description -->


### PR DESCRIPTION
## Summary
- add top margin/padding to footer so it no longer sits flush against page content
- simplify contact page layout by removing background box

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889222c3bf88325baeb3a767054dd94