### PR TITLE
Update docs for new logo assets

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ Kho lưu trữ này bao gồm backend Flask quản lý domain và DNS cùng vớ
 - `backend_endpoints.md` – các route Flask hiện có.
 - `backend_guidelines.md` – quy tắc comment và mô tả cấu trúc backend.
 - `frontend_routes.md` – các đường dẫn router React cho phần frontend.
+- Các logo SVG mẫu được đặt trong thư mục `static/images/logo` để dùng cho
+  `template_default`.
 
 Mỗi phần dưới đây mô tả ngắn gọn mục đích của backend và frontend.
 

--- a/docs/backend_models.md
+++ b/docs/backend_models.md
@@ -58,7 +58,8 @@ Dưới đây là tóm tắt các model SQLAlchemy được định nghĩa trong
 - `email`: email liên hệ
 - `license_no`: số giấy phép kinh doanh
 - `google_map_embed`: mã nhúng Google Map hoặc liên kết
-- `logo_url`: đường dẫn logo
+- `logo_url`: đường dẫn logo. Có thể chọn một file SVG trong thư mục
+  `static/images/logo` của dự án hoặc dùng URL bên ngoài.
 - `footer_text`: nội dung footer
 - `description`: mô tả về công ty (tùy chọn)
 - `note`: ghi chú mở rộng

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -36,7 +36,8 @@ GenWeb/
 - **models/** – Các model SQLAlchemy: `User`, `Domain`, `DNSRecord`, `CloudflareAccount`, `Company`, `Website`, `Template`, `Product`, `Order`, `OrderItem`, `UserFE`...
 - **routes/** – Các blueprint Flask phân theo chức năng (`auth`, `domain`, `dns`, `cloudflare_account`, `admin`, `home`).
 - **templates/** – Giao diện Jinja2 dùng để render trang HTML.
-- **static/** – Tài nguyên tĩnh (CSS, JS) phục vụ template.
+- **static/** – Tài nguyên tĩnh (CSS, JS, hình ảnh) phục vụ template. Thư mục
+  `static/images/logo` chứa các logo SVG mẫu cho `template_default`.
 - **seeder/** – Script khởi tạo dữ liệu mẫu như user admin, Cloudflare account, template, company và danh sách sản phẩm.
 - **util/** – Hàm tiện ích, đặc biệt `cloud_flare.py` thao tác API Cloudflare.
 - **Form/** – Định nghĩa các WTForms cho đăng ký, đăng nhập và form cấu hình domain.


### PR DESCRIPTION
## Summary
- describe new static logo folder in docs
- clarify Company `logo_url` usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm install --silent` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68893f1ca8348325b959b681bd9d0c5b